### PR TITLE
Add KML/KMZ export option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,5 @@ TestFixed.csv
 TestFixedASL.csv
 FinalTest.csv
 *_output.csv
+!cmd/fp2lm/
+!cmd/fp2lm/**

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ fp2lm [options] < FlightplannerMission.csv > LitchiMission.csv
 - `-pitch <angle>`: Gimbal pitch angle (-90 to 0 degrees). Default: `-90`
 - `-max-altitude <meters>`: Maximum allowed altitude AGL in meters. Default: `120` (to comply with regulations)
 - `-output <path>`: Output file path (if not specified, writes to stdout)
+- `-format <csv|kml|kmz>`: Output format. Default `csv`. Use `kml` for Google Earth files or `kmz` for compressed output.
 
 ## Description
 
@@ -81,8 +82,11 @@ Alternatively, you can build from source by following the instructions below.
 
 3. Make the binary executable and run it directly:
    ```
-   chmod +x ./fp2lm
-   ./fp2lm -d 20m < FlightplannerMission.csv > LitchiMission.csv
+chmod +x ./fp2lm
+./fp2lm -d 20m < FlightplannerMission.csv > LitchiMission.csv
+
+# Generate KML instead of CSV
+./fp2lm -format=kml -d 20m < FlightplannerMission.csv > mission.kml
    ```
 
 #### Advanced Setup (adding to PATH)

--- a/cmd/fp2lm/main.go
+++ b/cmd/fp2lm/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"flightplan2litchimission/fp2lm"
+	"flightplan2litchimission/lenconv"
+	"flightplan2litchimission/missionkml"
+)
+
+func main() {
+	interval := lenconv.PhotoIntervalFlag("d", 0, "Photo interval distance (e.g. 20m or 60ft)")
+	altitudeMode := flag.String("altitude-mode", "agl", "Altitude mode: agl or asl")
+	pitch := flag.Float64("pitch", -90, "Gimbal pitch angle (-90 to 0)")
+	maxAlt := flag.Float64("max-altitude", 120, "Maximum allowed altitude AGL in meters")
+	outputPath := flag.String("output", "", "Output file path")
+	format := flag.String("format", "csv", "Output format: csv, kml or kmz")
+	flag.Parse()
+
+	opts := &fp2lm.ConverterOptions{
+		AltitudeMode:   *altitudeMode,
+		PhotoInterval:  lenconv.Meters(*interval),
+		GimbalPitch:    *pitch,
+		MaxAltitudeAGL: *maxAlt,
+	}
+
+	var out io.Writer = os.Stdout
+	var file *os.File
+	var err error
+	if *outputPath != "" {
+		file, err = os.Create(*outputPath)
+		if err != nil {
+			log.Fatalf("failed to create output file: %v", err)
+		}
+		defer file.Close()
+		out = file
+	}
+
+	switch *format {
+	case "csv":
+		if err := fp2lm.Process(os.Stdin, out, opts); err != nil {
+			log.Fatal(err)
+		}
+	case "kml", "kmz":
+		waypoints, err := fp2lm.ConvertWaypoints(os.Stdin, opts)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if *format == "kml" {
+			if err := missionkml.WriteKML(out, waypoints); err != nil {
+				log.Fatal(err)
+			}
+		} else {
+			if err := missionkml.WriteKMZ(out, waypoints); err != nil {
+				log.Fatal(err)
+			}
+		}
+	default:
+		log.Fatalf("unknown format %q", *format)
+	}
+
+	if file != nil {
+		fmt.Fprintln(os.Stderr, "wrote", *outputPath)
+	}
+}

--- a/missionkml/kml.go
+++ b/missionkml/kml.go
@@ -1,0 +1,52 @@
+package missionkml
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+
+	"flightplan2litchimission/missioncsv"
+)
+
+// WriteKML writes KML representing the provided waypoints.
+func WriteKML(w io.Writer, wps []*missioncsv.LitchiWaypoint) error {
+	if _, err := fmt.Fprintln(w, `<?xml version="1.0" encoding="UTF-8"?>`); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, `<kml xmlns="http://www.opengis.net/kml/2.2">`); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, `<Document>`); err != nil {
+		return err
+	}
+	for i, wp := range wps {
+		if _, err := fmt.Fprintf(w, "  <Placemark>\n    <name>%d</name>\n    <Point><coordinates>%.7f,%.7f,%.3f</coordinates></Point>\n  </Placemark>\n", i+1, wp.Point.Longitude, wp.Point.Latitude, wp.Point.Altitude); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintln(w, `</Document>`); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, `</kml>`); err != nil {
+		return err
+	}
+	return nil
+}
+
+// WriteKMZ writes a KMZ archive containing a doc.kml generated from the waypoints.
+func WriteKMZ(w io.Writer, wps []*missioncsv.LitchiWaypoint) error {
+	var buf bytes.Buffer
+	if err := WriteKML(&buf, wps); err != nil {
+		return err
+	}
+	zw := zip.NewWriter(w)
+	f, err := zw.Create("doc.kml")
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(buf.Bytes()); err != nil {
+		return err
+	}
+	return zw.Close()
+}

--- a/missionkml/kml_test.go
+++ b/missionkml/kml_test.go
@@ -1,0 +1,73 @@
+package missionkml
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"flightplan2litchimission/fp2lm"
+	"flightplan2litchimission/missioncsv"
+)
+
+var samplePath = "../fp2lm/testdata/FlightplannerMission.csv"
+
+func getWaypoints(t *testing.T) []*missioncsv.LitchiWaypoint {
+	t.Helper()
+	data, err := os.ReadFile(samplePath)
+	if err != nil {
+		t.Fatalf("read sample: %v", err)
+	}
+	options := &fp2lm.ConverterOptions{AltitudeMode: "agl", GimbalPitch: -90, MaxAltitudeAGL: 120}
+	wps, err := fp2lm.ConvertWaypoints(bytes.NewReader(data), options)
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	return wps
+}
+
+func TestWriteKML(t *testing.T) {
+	wps := getWaypoints(t)
+	var buf bytes.Buffer
+	if err := WriteKML(&buf, wps); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	out := buf.String()
+	if !bytes.Contains(buf.Bytes(), []byte("<kml")) {
+		t.Errorf("missing kml tag")
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("<Placemark>")) {
+		t.Errorf("missing placemark")
+	}
+	if len(out) == 0 {
+		t.Errorf("no output")
+	}
+}
+
+func TestWriteKMZ(t *testing.T) {
+	wps := getWaypoints(t)
+	var buf bytes.Buffer
+	if err := WriteKMZ(&buf, wps); err != nil {
+		t.Fatalf("write kmz failed: %v", err)
+	}
+	r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatalf("zip read: %v", err)
+	}
+	if len(r.File) != 1 || r.File[0].Name != "doc.kml" {
+		t.Fatalf("kmz missing doc.kml")
+	}
+	f, err := r.File[0].Open()
+	if err != nil {
+		t.Fatalf("open kml: %v", err)
+	}
+	data, err := io.ReadAll(f)
+	f.Close()
+	if err != nil {
+		t.Fatalf("read kml: %v", err)
+	}
+	if !bytes.Contains(data, []byte("<kml")) {
+		t.Errorf("kml not found in kmz")
+	}
+}


### PR DESCRIPTION
## Summary
- add a CLI under `cmd/fp2lm` with a new `--format` flag supporting csv/kml/kmz
- export `ConvertWaypoints` to share waypoint creation logic
- implement `missionkml` package that outputs KML or KMZ
- document the new flag in README with example
- test KML/KMZ generation

## Testing
- `go test ./...`
